### PR TITLE
fix(matplotlib-versioning): use (greater) inclusive ordered compariso…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ pydot==1.4.2
 networkx==2.5
 redis==3.5.3
 diskcache==5.2.1
-matplotlib==3.3.3
+matplotlib>=3.3.3
 dill==0.3.3
 cloudpickle==1.6.0


### PR DESCRIPTION
…n for later versions of python

This commit fixes issue #5